### PR TITLE
Add lineContents to ProcessLine callback

### DIFF
--- a/cmd/strip-comments/main.go
+++ b/cmd/strip-comments/main.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/boyter/scc/v3/processor"
+)
+
+type statsProcessor struct{}
+
+func (p *statsProcessor) ProcessLine(job *processor.FileJob, lineContents []byte, currentLine int64, lineType processor.LineType) bool {
+	if lineType == processor.LINE_CODE {
+		fmt.Print(string(lineContents))
+	}
+	return true
+}
+
+func main() {
+
+	inputFile := flag.String("inputFile", "", "File path to strip comments from")
+	language := flag.String("language", "C", "Language of file to strip comments from")
+
+	flag.Parse()
+
+	input, err := os.ReadFile(*inputFile)
+
+	if err != nil {
+		log.Fatalf("Failed to ReadFile: %v", err)
+	}
+
+	processor.ProcessConstants() // Required to load the language information and need only be done once
+
+	t := &statsProcessor{}
+	filejob := &processor.FileJob{
+		Language: *language,
+		Content:  input,
+		Callback: t,
+		Bytes:    int64(len(input)),
+	}
+
+	processor.CountStats(filejob)
+}

--- a/processor/structs.go
+++ b/processor/structs.go
@@ -59,7 +59,7 @@ type LanguageFeature struct {
 // FileJobCallback is an interface that FileJobs can implement to get a per line callback with the line type
 type FileJobCallback interface {
 	// ProcessLine should return true to continue processing or false to stop further processing and return
-	ProcessLine(job *FileJob, currentLine int64, lineType LineType) bool
+	ProcessLine(job *FileJob, lineContents []byte, currentLine int64, lineType LineType) bool
 }
 
 // FileJob is a struct used to hold all of the results of processing internally before sent to the formatter


### PR DESCRIPTION
This facilitates stripping comments from files, which we take advantage of in the [strip-comments](./cmd/strip-comments/main.go) command.